### PR TITLE
convert name to ASCII-only when generating bibtex label

### DIFF
--- a/article.py
+++ b/article.py
@@ -1,5 +1,6 @@
 # ReScience yaml parser
 # Released under the BSD two-clauses licence
+import unicodedata
 
 import yaml
 import dateutil.parser
@@ -154,6 +155,14 @@ class Article:
 
                 self.authors_full += self.authors[n-2].fullname + " and "
                 self.authors_full += self.authors[n-1].fullname
+
+        # create ASCII bibtex label
+        # - Try to convert unicode character to their ASCII equivalent
+        bibtex_label_bytes = \
+        unicodedata.normalize('NFKD', self.authors[0].lastname).encode('ascii',
+                                                                       'ignore')
+        self.bibtex_label = str(bibtex_label_bytes, 'ascii')
+
 
             
         

--- a/yaml-to-bibtex.py
+++ b/yaml-to-bibtex.py
@@ -4,7 +4,7 @@
 
 def generate_bibtex(filename, article):
     content = (
-        "@Article {{{_.authors[0].lastname}:{_.date_published.year},\n"
+        "@Article {{{_.bibtex_label}:{_.date_published.year},\n"
         "  author =       {{{_.authors_full}}},\n"
         "  title =        {{{{{_.title}}}}},\n"
         "  journal =      {{{_.journal_name}}},\n"


### PR DESCRIPTION
Convert first author's name to ASCII only when generating the bibtex label.

This uses the [NFKD](https://unicode.org/reports/tr15/) unicode normalization form and then a round trip to 'ascii' to remove diacritical marks (like accents, cedilla, etc...).