### PR TITLE
fix duplicate bibtex labels

### DIFF
--- a/10.5281_zenodo.3886447/article.bib
+++ b/10.5281_zenodo.3886447/article.bib
@@ -1,4 +1,4 @@
-@Article {Hinsen:2020,
+@Article {Hinsen:2020a,
   author =       {Konrad Hinsen},
   title =        {{[Rp] Structural flexibility in proteins - impact of the crystal environment}},
   journal =      {ReScience C},

--- a/10.5281_zenodo.3889694/article.bib
+++ b/10.5281_zenodo.3889694/article.bib
@@ -1,4 +1,4 @@
-@Article {Hinsen:2020,
+@Article {Hinsen:2020b,
   author =       {Konrad Hinsen},
   title =        {{[¬Rp] Stokes drag on conglomerates of spheres}},
   journal =      {ReScience C},


### PR DESCRIPTION
This fixes the issue with duplicate labels for Hinsen:2020